### PR TITLE
feature/gitconfig-custom-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,12 @@ The default values for the variables are set in `defaults/main.yml`:
 # git_groupname: "{{ git_username }}"
 
 # Settings for git configuration.
-# git_user_email: johndoe@example.com
-# git_user_name: John Doe
+# git_config:
+#   user:
+#     name: John Doe
+#     email: johndoe@example.com
+#   <setcion>:
+#     <key>: <value>
 
 # Where to place the copies of the repositories.
 git_repository_destination: /home/{{ git_username | default('unset') }}/Documents/github.com/{{ git_username | default('unset') }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,12 @@
 # git_groupname: "{{ git_username }}"
 
 # Settings for git configuration.
-# git_user_email: johndoe@example.com
-# git_user_name: John Doe
+# git_config:
+#   user:
+#     name: John Doe
+#     email: johndoe@example.com
+#   <setcion>:
+#     <key>: <value>
 
 # Where to place the copies of the repositories.
 git_repository_destination: /home/{{ git_username | default('unset') }}/Documents/github.com/{{ git_username | default('unset') }}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -17,6 +17,10 @@
       - repo: https://github.com/buluma/ansible-role-bootstrap
         dest: bootstrap-version
         version: "v2.0.0"
+    git_config:
+      user:
+        name: John Doe
+        email: johndoe@example.com
 
   roles:
     - role: ansible-role-git

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -44,3 +44,12 @@
   when:
     - git_repositories is defined
     - item.force is defined
+
+- name: test if value in git_config.section is set correctly
+  ansible.builtin.assert:
+    that:
+      - item is defined
+    quiet: yes
+  with_items: "{{ git_config.items() }}"
+  when:
+    - git_config.items() is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,54 +19,52 @@
   when:
     - git_username is defined
 
-- name: create directory for git configuration
-  ansible.builtin.file:
-    path: /home/{{ git_username }}
-    state: directory
-    owner: "{{ git_username | default(omit) }}"
-    group: "{{ git_groupname | default(omit) }}"
-    mode: "0755"
-  when:
-    - getent_passwd is defined
-    - getent_passwd[git_username] != none
+- block:
+    - name: create directory for git configuration
+      ansible.builtin.file:
+        path: /home/{{ git_username }}
+        state: directory
+        owner: "{{ git_username | default(omit) }}"
+        group: "{{ git_groupname | default(omit) }}"
+        mode: "0755"
+      when:
+        - getent_passwd is defined
 
-- name: place git configuration
-  ansible.builtin.template:
-    src: gitconfig.j2
-    dest: /home/{{ git_username }}/.gitconfig
-    mode: "0644"
-  when:
-    - git_user_email is defined
-    - git_user_name is defined
-    - git_username is defined
-    - getent_passwd[git_username] != none
+    - name: place git configuration
+      ansible.builtin.template:
+        src: gitconfig.j2
+        dest: /home/{{ git_username }}/.gitconfig
+        mode: "0644"
+      when:
+        - git_config is defined
+        - git_username is defined
 
-- name: create repository_destination
-  ansible.builtin.file:
-    path: "{{ git_repository_destination }}"
-    state: directory
-    owner: "{{ git_username | default(omit) }}"
-    group: "{{ git_groupname | default(omit) }}"
-    mode: "0750"
-  when:
-    - git_username is defined
-    - git_repository_destination is defined
-    - getent_passwd[git_username] != none
+    - name: create repository_destination
+      ansible.builtin.file:
+        path: "{{ git_repository_destination }}"
+        state: directory
+        owner: "{{ git_username | default(omit) }}"
+        group: "{{ git_groupname | default(omit) }}"
+        mode: "0750"
+      when:
+        - git_username is defined
+        - git_repository_destination is defined
 
-- name: clone all roles
-  ansible.builtin.git:
-    repo: "{{ item.repo }}"
-    dest: "{{ git_repository_destination }}/{{ item.dest }}"
-    accept_hostkey: yes
-    version: "{{ item.version | default('HEAD') }}"
-    force: "{{ item.force | default(git_force) }}"
-  loop: "{{ git_repositories }}"
-  loop_control:
-    label: "{{ item.dest }}"
-  become: yes
-  become_user: "{{ git_username }}"
+    - name: clone all roles
+      ansible.builtin.git:
+        repo: "{{ item.repo }}"
+        dest: "{{ git_repository_destination }}/{{ item.dest }}"
+        accept_hostkey: yes
+        version: "{{ item.version | default('HEAD') }}"
+        force: "{{ item.force | default(git_force) }}"
+      loop: "{{ git_repositories }}"
+      loop_control:
+        label: "{{ item.dest }}"
+      become: yes
+      become_user: "{{ git_username }}"
+      when:
+        - git_repositories is defined
+        - git_repository_destination is defined
+        - git_username is defined
   when:
-    - git_repositories is defined
-    - git_repository_destination is defined
-    - git_username is defined
     - getent_passwd[git_username] != none

--- a/templates/gitconfig.j2
+++ b/templates/gitconfig.j2
@@ -1,5 +1,8 @@
 {{ ansible_managed | comment }}
 
-[user]
-	email = {{ git_user_email }}
-	name = {{ git_user_name }}
+{% for section, values in git_config.items() %}
+[{{ section }}]
+{% for key, value in values.items() %}
+    {{ key }} = {{ value }}
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
Modified gitconfig.j2 template to include options forr custom templating
of gitconfig file. This means that custom sections along with key/value
pairs are allowed in configuration instead of only name and email.

Along with this, modified the README and default values to reflect these
changes.

Molecule Converge has been updated to include the git_config option as
well. Assertion is tested for each section and item value.